### PR TITLE
Remove default features from the workspace bevy_mod_picking dependency.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -788,11 +788,8 @@ dependencies = [
  "bevy_eventlistener",
  "bevy_math",
  "bevy_picking_core",
- "bevy_picking_highlight",
  "bevy_picking_input",
  "bevy_picking_raycast",
- "bevy_picking_selection",
- "bevy_picking_sprite",
  "bevy_picking_ui",
  "bevy_reflect",
  "bevy_render",
@@ -880,24 +877,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bevy_picking_highlight"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba45161608da1bb58cbc55fd83cf5e529e616a180778c394733c85056cd2b76"
-dependencies = [
- "bevy_app",
- "bevy_asset",
- "bevy_color",
- "bevy_ecs",
- "bevy_pbr",
- "bevy_picking_core",
- "bevy_picking_selection",
- "bevy_reflect",
- "bevy_render",
- "bevy_sprite",
-]
-
-[[package]]
 name = "bevy_picking_input"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,7 +888,6 @@ dependencies = [
  "bevy_input",
  "bevy_math",
  "bevy_picking_core",
- "bevy_picking_selection",
  "bevy_reflect",
  "bevy_render",
  "bevy_utils",
@@ -928,38 +906,6 @@ dependencies = [
  "bevy_picking_core",
  "bevy_reflect",
  "bevy_render",
- "bevy_transform",
- "bevy_window",
-]
-
-[[package]]
-name = "bevy_picking_selection"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0769d84e944fbc09b0475f068e5232a8a4be15339796539aecd747413ededd"
-dependencies = [
- "bevy_app",
- "bevy_ecs",
- "bevy_eventlistener",
- "bevy_input",
- "bevy_picking_core",
- "bevy_reflect",
- "bevy_utils",
-]
-
-[[package]]
-name = "bevy_picking_sprite"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fcbde61e315f78b027f4b03f42339307b1f5ffef4f514e39007e9fb2be8aea5"
-dependencies = [
- "bevy_app",
- "bevy_asset",
- "bevy_ecs",
- "bevy_math",
- "bevy_picking_core",
- "bevy_render",
- "bevy_sprite",
  "bevy_transform",
  "bevy_window",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ verbose = [] # Enable verbose logging
 [workspace.dependencies]
 bevy = "0.14.0"
 bevy_mod_stylebuilder = { path = "crates/bevy_mod_stylebuilder", version = "0.1.1" }
-bevy_mod_picking = "0.20.1"
+bevy_mod_picking = { version = "0.20.1", default-features = false }
 bevy_quill_core = { path = "crates/bevy_quill_core", version = "0.1.0" }
 bevy_quill_obsidian = { path = "crates/bevy_quill_obsidian", version = "0.1.0" }
 bevy_quill_obsidian_inspect = { path = "crates/bevy_quill_obsidian_inspect", version = "0.1.0" }
@@ -35,7 +35,7 @@ smallvec = "1.13.2"
 
 [dev-dependencies]
 bevy_quill_obsidian = { path = "crates/bevy_quill_obsidian" }
-bevy_mod_picking = { workspace = true }
+bevy_mod_picking = { workspace = true, features = ["debug", "backend_raycast", "backend_bevy_ui"] }
 bevy_quill_obsidian_inspect = { workspace = true }
 # bevy_reactor_overlays = { path = "crates/bevy_reactor_overlays" }
 # bevy_picking_backdrop = { path = "crates/bevy_picking_backdrop" }

--- a/crates/bevy_vortex/Cargo.toml
+++ b/crates/bevy_vortex/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["bevy", "ui", "reactive"]
 
 [dependencies]
 bevy = { workspace = true }
-bevy_mod_picking = { workspace = true }
+bevy_mod_picking = { workspace = true, features = ["debug"] }
 bevy_mod_stylebuilder = { workspace = true }
 bevy_quill = { path = "../.." }
 bevy_quill_core = { workspace = true }


### PR DESCRIPTION
Was playing around with the stylebuilder from this repo (very cool) and noticed that adding the dependency pulled in a couple of extra things via bevy_mod_picking. In my project I have default-features off for this crate but because stylebuilder depends on bevy_mod_picking with default features they all get enabled anyway.

Most crates here don't need anything besides the core (AFAICT) so using default-features = false and enabling where needed could make sense.