### PR TITLE
feat: Add ability to build `Icon` and friends with either `Handle<Image>` or `&str`

### DIFF
--- a/crates/bevy_mod_stylebuilder/src/builder.rs
+++ b/crates/bevy_mod_stylebuilder/src/builder.rs
@@ -220,25 +220,36 @@ impl OptFloatParam for i32 {
     }
 }
 
-/// Trait that represents an optional float
-pub trait AssetPathParam<'a> {
-    fn to_path(self) -> Option<AssetPath<'a>>;
+/// Enum that represents either a handle or an asset path or nothing.
+pub enum MaybeHandleOrPath<'a, T: Asset> {
+    None,
+    Handle(Handle<T>),
+    Path(AssetPath<'a>),
 }
 
-impl<'a> AssetPathParam<'a> for Option<AssetPath<'a>> {
-    fn to_path(self) -> Option<AssetPath<'a>> {
-        self
+impl<T: Asset> From<Handle<T>> for MaybeHandleOrPath<'_, T> {
+    fn from(h: Handle<T>) -> Self {
+        MaybeHandleOrPath::Handle(h)
     }
 }
 
-impl<'a> AssetPathParam<'a> for AssetPath<'a> {
-    fn to_path(self) -> Option<AssetPath<'a>> {
-        Some(self)
+impl<'a, T: Asset> From<AssetPath<'a>> for MaybeHandleOrPath<'a, T> {
+    fn from(p: AssetPath<'a>) -> Self {
+        MaybeHandleOrPath::Path(p)
     }
 }
 
-impl<'a> AssetPathParam<'a> for &'a str {
-    fn to_path(self) -> Option<AssetPath<'a>> {
-        Some(AssetPath::parse(self))
+impl<'a, T: Asset> From<&'a str> for MaybeHandleOrPath<'a, T> {
+    fn from(p: &'a str) -> Self {
+        MaybeHandleOrPath::Path(AssetPath::parse(p))
+    }
+}
+
+impl<'a, T: Asset> From<Option<AssetPath<'a>>> for MaybeHandleOrPath<'a, T> {
+    fn from(p: Option<AssetPath<'a>>) -> Self {
+        match p {
+            Some(p) => MaybeHandleOrPath::Path(p),
+            None => MaybeHandleOrPath::None,
+        }
     }
 }

--- a/crates/bevy_mod_stylebuilder/src/builder.rs
+++ b/crates/bevy_mod_stylebuilder/src/builder.rs
@@ -229,6 +229,12 @@ pub enum HandleOrOwnedPath<T: Asset> {
     Path(String),
 }
 
+impl<T: Asset> Default for HandleOrOwnedPath<T> {
+    fn default() -> Self {
+        Self::Path("".to_string())
+    }
+}
+
 // Necessary because we don't want to require T: PartialEq
 impl<T: Asset> PartialEq for HandleOrOwnedPath<T> {
     fn eq(&self, other: &Self) -> bool {
@@ -237,6 +243,36 @@ impl<T: Asset> PartialEq for HandleOrOwnedPath<T> {
             (HandleOrOwnedPath::Path(p1), HandleOrOwnedPath::Path(p2)) => p1 == p2,
             _ => false,
         }
+    }
+}
+
+impl<T: Asset> From<Handle<T>> for HandleOrOwnedPath<T> {
+    fn from(h: Handle<T>) -> Self {
+        HandleOrOwnedPath::Handle(h)
+    }
+}
+
+impl<T: Asset> From<&str> for HandleOrOwnedPath<T> {
+    fn from(p: &str) -> Self {
+        HandleOrOwnedPath::Path(p.to_string())
+    }
+}
+
+impl<T: Asset> From<String> for HandleOrOwnedPath<T> {
+    fn from(p: String) -> Self {
+        HandleOrOwnedPath::Path(p.clone())
+    }
+}
+
+impl<T: Asset> From<&String> for HandleOrOwnedPath<T> {
+    fn from(p: &String) -> Self {
+        HandleOrOwnedPath::Path(p.to_string())
+    }
+}
+
+impl<T: Asset> From<&HandleOrOwnedPath<T>> for HandleOrOwnedPath<T> {
+    fn from(p: &HandleOrOwnedPath<T>) -> Self {
+        p.to_owned().into()
     }
 }
 

--- a/crates/bevy_mod_stylebuilder/src/builder_texture_atlas.rs
+++ b/crates/bevy_mod_stylebuilder/src/builder_texture_atlas.rs
@@ -1,11 +1,11 @@
 use bevy::{sprite::TextureAtlas, ui::UiTextureAtlasImage};
 
-use super::builder::{AssetPathParam, StyleBuilder};
+use super::builder::{MaybeHandleOrPath, StyleBuilder};
 
 #[allow(missing_docs)]
 pub trait StyleBuilderTextureAtlas {
     /// Set the background image of the target entity.
-    fn texture_atlas<'p>(&mut self, path: impl AssetPathParam<'p>) -> &mut Self;
+    fn texture_atlas<'p>(&mut self, path: impl Into<MaybeHandleOrPath<'p, TextureAtlas>>) -> &mut Self;
 
     /// Set the index of which tile is being used in the texture atlas
     fn texture_atlas_tile(&mut self, index: usize) -> &mut Self;
@@ -21,7 +21,7 @@ pub trait StyleBuilderTextureAtlas {
 }
 
 impl<'a, 'w> StyleBuilderTextureAtlas for StyleBuilder<'a, 'w> {
-    fn texture_atlas<'p>(&mut self, path: impl AssetPathParam<'p>) -> &mut Self {
+    fn texture_atlas<'p>(&mut self, path: impl Into<MaybeHandleOrPath<'p, TextureAtlas>>) -> &mut Self {
         todo!("Implement texture atlas loading");
         // let texture = path
         //     .to_path()

--- a/crates/bevy_quill_obsidian/src/controls/icon.rs
+++ b/crates/bevy_quill_obsidian/src/controls/icon.rs
@@ -1,4 +1,4 @@
-use bevy::{asset::AssetPath, prelude::*};
+use bevy::prelude::*;
 use bevy_mod_stylebuilder::*;
 use bevy_quill_core::*;
 
@@ -8,7 +8,7 @@ use crate::colors;
 #[derive(Clone, PartialEq)]
 pub struct Icon {
     /// Asset path for the icon
-    pub icon: String,
+    pub icon: HandleOrOwnedPath<Image>,
 
     /// Size of the icon in pixels.
     pub size: Vec2,
@@ -24,7 +24,14 @@ impl Icon {
     /// Create a new icon.
     pub fn new(icon: &str) -> Self {
         Self {
-            icon: icon.to_string(),
+            icon: HandleOrOwnedPath::Path(icon.to_string()),
+            ..default()
+        }
+    }
+
+    pub fn from_handle(icon: Handle<Image>) -> Self {
+        Self {
+            icon: HandleOrOwnedPath::Handle(icon),
             ..default()
         }
     }
@@ -51,7 +58,7 @@ impl Icon {
 impl Default for Icon {
     fn default() -> Self {
         Self {
-            icon: "".to_string(),
+            icon: HandleOrOwnedPath::Path("".to_string()),
             size: Vec2::splat(12.0),
             color: colors::FOREGROUND,
             style: StyleHandle::default(),
@@ -68,9 +75,7 @@ impl ViewTemplate for Icon {
         Element::<NodeBundle>::new()
             .style((
                 move |sb: &mut StyleBuilder| {
-                    sb.width(size.x)
-                        .height(size.y)
-                        .background_image(AssetPath::parse(&icon));
+                    sb.width(size.x).height(size.y).background_image(&icon);
                 },
                 self.style.clone(),
             ))

--- a/crates/bevy_quill_obsidian/src/controls/icon.rs
+++ b/crates/bevy_quill_obsidian/src/controls/icon.rs
@@ -21,17 +21,10 @@ pub struct Icon {
 }
 
 impl Icon {
-    /// Create a new icon.
-    pub fn new(icon: &str) -> Self {
+    /// Create a new `Icon` from a `&str` or `Handle<Image>`.
+    pub fn new(icon: impl Into<HandleOrOwnedPath<Image>>) -> Self {
         Self {
-            icon: HandleOrOwnedPath::Path(icon.to_string()),
-            ..default()
-        }
-    }
-
-    pub fn from_handle(icon: Handle<Image>) -> Self {
-        Self {
-            icon: HandleOrOwnedPath::Handle(icon),
+            icon: icon.into(),
             ..default()
         }
     }
@@ -58,7 +51,7 @@ impl Icon {
 impl Default for Icon {
     fn default() -> Self {
         Self {
-            icon: HandleOrOwnedPath::Path("".to_string()),
+            icon: HandleOrOwnedPath::default(),
             size: Vec2::splat(12.0),
             color: colors::FOREGROUND,
             style: StyleHandle::default(),

--- a/crates/bevy_quill_obsidian/src/controls/icon_button.rs
+++ b/crates/bevy_quill_obsidian/src/controls/icon_button.rs
@@ -8,7 +8,7 @@ use bevy_quill_core::*;
 #[derive(Default, Clone, PartialEq)]
 pub struct IconButton {
     /// Asset path for the icon
-    pub icon: String,
+    pub icon: HandleOrOwnedPath<Image>,
 
     /// Color variant - default, primary or danger.
     // pub variant: ButtonVariant,
@@ -39,10 +39,10 @@ pub struct IconButton {
 }
 
 impl IconButton {
-    /// Construct a new `IconButton`.
-    pub fn new(icon: &str) -> Self {
+    /// Construct a new `IconButton` from a `&str` or `Handle<Image>`.
+    pub fn new(icon: impl Into<HandleOrOwnedPath<Image>>) -> Self {
         Self {
-            icon: icon.to_string(),
+            icon: icon.into(),
             ..default()
         }
     }

--- a/crates/bevy_quill_obsidian/src/controls/tool_palette.rs
+++ b/crates/bevy_quill_obsidian/src/controls/tool_palette.rs
@@ -225,7 +225,7 @@ impl ViewTemplate for ToolButton {
 #[derive(Clone, PartialEq)]
 pub struct ToolIconButton {
     /// Icon to display as the button content.
-    pub(crate) icon: String,
+    pub(crate) icon: HandleOrOwnedPath<Image>,
 
     /// Size of the icon in pixels.
     pub(crate) size: Vec2,
@@ -257,9 +257,9 @@ pub struct ToolIconButton {
 
 impl ToolIconButton {
     /// Create a new [`ToolIconButton`].
-    pub fn new(icon: &str) -> Self {
+    pub fn new(icon: impl Into<HandleOrOwnedPath<Image>>) -> Self {
         Self {
-            icon: icon.to_string(),
+            icon: icon.into(),
             variant: Default::default(),
             disabled: Default::default(),
             style: StyleHandle::default(),


### PR DESCRIPTION
This is especially useful for interoperability with [bevy_asset_loader](https://github.com/NiklasEi/bevy_asset_loader).

This implements the request in #7.

I also removed the need for a custom trait by instead using `Into` on a new enum.