### PR TITLE
fix wireless recursion

### DIFF
--- a/crates/bevy_mod_stylebuilder/src/builder.rs
+++ b/crates/bevy_mod_stylebuilder/src/builder.rs
@@ -270,7 +270,7 @@ impl<T: Asset> From<&String> for HandleOrOwnedPath<T> {
     }
 }
 
-impl<T: Asset> From<&HandleOrOwnedPath<T>> for HandleOrOwnedPath<T> {
+impl<T: Asset + Clone> From<&HandleOrOwnedPath<T>> for HandleOrOwnedPath<T> {
     fn from(p: &HandleOrOwnedPath<T>) -> Self {
         p.to_owned().into()
     }


### PR DESCRIPTION
if T doesn't impl Clone trait, `p.to_owned()` will just got the `&HandleOrOwnedPath<T>` instead of `HandleOrOwnedPath<T>`, and causing wireless recursion.