### PR TITLE
fix: Wgpu padding bug for wasm

### DIFF
--- a/crates/bevy_quill_obsidian/src/assets/shaders/gradient_rect.wgsl
+++ b/crates/bevy_quill_obsidian/src/assets/shaders/gradient_rect.wgsl
@@ -2,19 +2,19 @@
 #import bevy_ui::ui_vertex_output::UiVertexOutput
 
 @group(1) @binding(0)
-var<uniform> num_color_stops: i32;
+var<uniform> num_color_stops: vec4<i32>;
 
 @group(1) @binding(1)
 var<uniform> color_stops: array<vec4<f32>, 8>;
 
 @group(1) @binding(3)
-var<uniform> cap_size: f32;
+var<uniform> cap_size: vec4<f32>;
 
 @fragment
 fn fragment(in: UiVertexOutput) -> @location(0) vec4<f32> {
-    let t = (in.uv.x - 0.1) * 1.0 / 0.8 * f32(num_color_stops - 1);
-    let color_index_lo = clamp(i32(floor(t)), 0, num_color_stops - 1);
-    let color_index_hi = clamp(i32(ceil(t)), 0, num_color_stops - 1);
+    let t = (in.uv.x - 0.1) * 1.0 / 0.8 * f32(num_color_stops.x - 1);
+    let color_index_lo = clamp(i32(floor(t)), 0, num_color_stops.x - 1);
+    let color_index_hi = clamp(i32(ceil(t)), 0, num_color_stops.x - 1);
     let color_lo = color_stops[color_index_lo];
     let color_hi = color_stops[color_index_hi];
     let color = mix(color_lo, color_hi, t - f32(color_index_lo));

--- a/crates/bevy_quill_obsidian/src/assets/shaders/slider_rect.wgsl
+++ b/crates/bevy_quill_obsidian/src/assets/shaders/slider_rect.wgsl
@@ -8,7 +8,7 @@ var<uniform> color_lo: vec4<f32>;
 var<uniform> color_hi: vec4<f32>;
 
 @group(1) @binding(2)
-var<uniform> value: f32;
+var<uniform> value: vec4<f32>;
 
 @group(1) @binding(3)
 var<uniform> radius: vec4<f32>;
@@ -17,7 +17,7 @@ var<uniform> radius: vec4<f32>;
 fn fragment(in: UiVertexOutput) -> @location(0) vec4<f32> {
     let uv = in.uv - 0.5;
     let size = vec2<f32>(in.size.x, in.size.y);
-    let color = select(color_lo, color_hi, in.uv.x <= value);
+    let color = select(color_lo, color_hi, in.uv.x <= value.x);
     let external_distance = sd_rounded_box((in.uv - 0.5) * size, size, vec4<f32>(radius));
     let alpha = smoothstep(0.5, -0.5, external_distance);
 

--- a/crates/bevy_quill_obsidian/src/controls/gradient_slider.rs
+++ b/crates/bevy_quill_obsidian/src/controls/gradient_slider.rs
@@ -254,8 +254,8 @@ impl ViewTemplate for GradientSlider {
                     .unwrap();
                 gradient_material_assets.add(GradientRectMaterial {
                     color_stops: [Srgba::default().to_vec4(); 8],
-                    num_color_stops: 2,
-                    cap_size: THUMB_WIDTH * 0.5,
+                    num_color_stops: IVec4::new(2, 0, 0, 0),
+                    cap_size: Vec4::new(THUMB_WIDTH * 0.5, 0., 0., 0.),
                 })
             },
             (),
@@ -269,7 +269,7 @@ impl ViewTemplate for GradientSlider {
                     .get_resource_mut::<Assets<GradientRectMaterial>>()
                     .unwrap();
                 let material = ui_materials.get_mut(material.id()).unwrap();
-                material.num_color_stops = num_color_stops as i32;
+                material.num_color_stops.x = num_color_stops as i32;
                 material.color_stops = color_stops;
             },
             (gradient_material.clone(), color_stops),

--- a/crates/bevy_quill_obsidian/src/controls/slider.rs
+++ b/crates/bevy_quill_obsidian/src/controls/slider.rs
@@ -235,7 +235,7 @@ impl ViewTemplate for Slider {
                 ui_materials.add(SliderRectMaterial {
                     color_lo: LinearRgba::from(colors::U1).to_vec4(),
                     color_hi: LinearRgba::from(colors::U3).to_vec4(),
-                    value: 0.5,
+                    value: Vec4::new(0.5, 0., 0., 0.),
                     radius: RoundedCorners::All.to_vec(4.),
                 })
             },
@@ -358,7 +358,7 @@ impl ViewTemplate for Slider {
                         .get_resource_mut::<Assets<SliderRectMaterial>>()
                         .unwrap();
                     let material = ui_materials.get_mut(material.id()).unwrap();
-                    material.value = pos;
+                    material.value.x = pos;
                 },
                 (self.min, self.max, self.value, material.clone()),
             )

--- a/crates/bevy_quill_obsidian/src/materials/gradient_rect.rs
+++ b/crates/bevy_quill_obsidian/src/materials/gradient_rect.rs
@@ -5,11 +5,11 @@ use bevy::render::render_resource::*;
 #[derive(AsBindGroup, Asset, TypePath, Debug, Clone)]
 pub(crate) struct GradientRectMaterial {
     #[uniform(0)]
-    pub(crate) num_color_stops: i32,
+    pub(crate) num_color_stops: IVec4,
     #[uniform(1)]
     pub(crate) color_stops: [Vec4; 8],
     #[uniform(3)]
-    pub(crate) cap_size: f32,
+    pub(crate) cap_size: Vec4,
 }
 
 impl UiMaterial for GradientRectMaterial {

--- a/crates/bevy_quill_obsidian/src/materials/slider_rect.rs
+++ b/crates/bevy_quill_obsidian/src/materials/slider_rect.rs
@@ -9,7 +9,7 @@ pub struct SliderRectMaterial {
     #[uniform(1)]
     pub(crate) color_hi: Vec4,
     #[uniform(2)]
-    pub(crate) value: f32,
+    pub(crate) value: Vec4,
     #[uniform(3)]
     pub(crate) radius: Vec4, // TopLeft, TopRight, BottomRight, BottomLeft
 }


### PR DESCRIPTION
This broke for me recently when I added a slider to my game. This fixes it.

We can probably do something more complicated, with `#cfg()` directives and what not, if we are worried about the excess 12 bytes of data. But I don't think it is really worth it.

I've found that this also affects the `controls` example. So I've updated the `gradient_rect.wgsl` as well.

[related](https://github.com/bevyengine/bevy/issues/5393) 
[other related](https://github.com/bevyengine/bevy/issues/13872)

```
wgpu error: Validation Error

Caused by:
    In Device::create_render_pipeline
      note: label = `ui_material_pipeline`
    In the provided shader, the type given for group 1 binding 2 has a
    size of 4. As the device does not support
    `DownlevelFlags::BUFFER_BINDINGS_NOT_16_BYTE_ALIGNED`, the type must
    have a size that is a multiple of 16 bytes.
```