### PR TITLE
fix: Fixes checkbox disappearing on focus

### DIFF
--- a/crates/bevy_quill_obsidian/src/controls/checkbox.rs
+++ b/crates/bevy_quill_obsidian/src/controls/checkbox.rs
@@ -231,7 +231,7 @@ impl ViewTemplate for Checkbox {
                             if focused {
                                 sb.outline_color(colors::FOCUS)
                                     .outline_offset(1.0)
-                                    .width(2.0);
+                                    .outline_width(2.0);
                             } else {
                                 sb.outline_color(Option::<Color>::None);
                             }


### PR DESCRIPTION

https://github.com/user-attachments/assets/4dc30913-e732-41c7-b098-bde069706154

Fixed an issue where the checkbox would disappear when focusing with the `Tab` key.