### PR TITLE
Disable default features for bevy and only include necessary dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ members = ["crates/*"]
 verbose = [] # Enable verbose logging
 
 [workspace.dependencies]
-bevy = "0.14.0"
 bevy_mod_stylebuilder = { path = "crates/bevy_mod_stylebuilder", version = "0.1.3" }
 bevy_mod_picking = { version = "0.20.1", default-features = false }
 bevy_quill_core = { path = "crates/bevy_quill_core", version = "0.1.3" }
@@ -26,6 +25,11 @@ bevy_quill_obsidian = { path = "crates/bevy_quill_obsidian", version = "0.1.3" }
 bevy_quill_obsidian_inspect = { path = "crates/bevy_quill_obsidian_inspect", version = "0.1.2" }
 bevy_quill_obsidian_graph = { path = "crates/bevy_quill_obsidian_graph", version = "0.1.2" }
 bevy_quill_overlays = { path = "crates/bevy_quill_overlays", version = "0.1.2" }
+
+[workspace.dependencies.bevy]
+version = "0.14"
+default-features = false
+features = ["bevy_ui"]
 
 [dependencies]
 bevy = { workspace = true }
@@ -35,6 +39,7 @@ impl-trait-for-tuples = "0.2.2"
 smallvec = "1.13.2"
 
 [dev-dependencies]
+bevy = { workspace = true, features = ["bevy_state", "multi_threaded"] }
 bevy_quill_obsidian = { path = "crates/bevy_quill_obsidian" }
 bevy_mod_picking = { workspace = true, features = [
   "debug",

--- a/crates/bevy_quill_overlays/Cargo.toml
+++ b/crates/bevy_quill_overlays/Cargo.toml
@@ -13,6 +13,6 @@ bevy_mod_picking = { workspace = true, features = [
   "backend_raycast",
   "backend_bevy_ui",
 ] }
-bevy = { workspace = true }
+bevy = { workspace = true, features = ["bevy_pbr"] }
 # bevy_mod_stylebuilder = { workspace = true }
 bevy_quill_core = { workspace = true }

--- a/crates/bevy_vortex/Cargo.toml
+++ b/crates/bevy_vortex/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/viridia/quill"
 keywords = ["bevy", "ui", "reactive"]
 
 [dependencies]
-bevy = { workspace = true }
+bevy = { workspace = true, features = ["bevy_state"] }
 bevy_mod_picking = { workspace = true, features = ["debug", "backend_bevy_ui"] }
 bevy_mod_stylebuilder = { workspace = true }
 bevy_quill = { path = "../.." }


### PR DESCRIPTION
Removes all bevy features except `bevy_ui` by default, to allow disabling features while using quill and improving compile times.

I've checked it by `cargo check` and `cargo test` and both succeed but am not 100% confident that nothing is broken.