### PR TITLE
Fix component hook registration

### DIFF
--- a/crates/bevy_quill_core/src/lib.rs
+++ b/crates/bevy_quill_core/src/lib.rs
@@ -21,7 +21,7 @@ mod view_child;
 mod view_template;
 
 use bevy::{
-    app::{App, Plugin, Startup, Update},
+    app::{App, Plugin, Update},
     prelude::IntoSystemConfigs,
 };
 use bevy_mod_stylebuilder::{StyleBuilderPlugin, StyleBuilderSystemSet};
@@ -69,13 +69,14 @@ pub struct QuillPlugin;
 
 impl Plugin for QuillPlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugins(StyleBuilderPlugin)
-            .add_systems(Startup, (cleanup_tracking_scopes, cleanup_view_roots))
-            .add_systems(
-                Update,
-                (build_views, reaction_control_system, reattach_children)
-                    .chain()
-                    .before(StyleBuilderSystemSet),
-            );
+        cleanup_tracking_scopes(app.world_mut());
+        cleanup_view_roots(app.world_mut());
+
+        app.add_plugins(StyleBuilderPlugin).add_systems(
+            Update,
+            (build_views, reaction_control_system, reattach_children)
+                .chain()
+                .before(StyleBuilderSystemSet),
+        );
     }
 }


### PR DESCRIPTION
Since bevy 0.14.1, [StateTransition now runs before PreStartup](https://github.com/bevyengine/bevy/pull/14208)

As a result, this example fails on bevy 0.14.1:
```rust
use bevy::prelude::*;
use bevy_quill::{Element, QuillPlugin, View};

#[derive(States, Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
pub struct Foo(pub bool);

fn main() {
    App::new()
        .add_plugins((
            DefaultPlugins.set(ImagePlugin::default_nearest()),
            QuillPlugin,
        ))
        .init_state::<Foo>()
        .add_systems(OnEnter(Foo(false)), on_enter)
        .run();
}

fn on_enter(mut commands: Commands) {
    commands.spawn((Element::<NodeBundle>::new().children("hello!").to_root(),));
}
```
With the following error:
```
Components hooks cannot be modified if the component already exists in an archetype, use init_component if bevy_quill_core::view::ViewRoot may already be in use
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Encountered a panic in system `bevy_quill_core::view::cleanup_view_roots`!
Encountered a panic in system `bevy_app::main_schedule::Main::run_main`!
```

This moves the registration earlier to ensure it runs before any ViewRoot is created