### PR TITLE
Revert "Disable default features for bevy and only include necessary dependencies"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = ["crates/*"]
 verbose = [] # Enable verbose logging
 
 [workspace.dependencies]
+bevy = "0.14.0"
 bevy_mod_stylebuilder = { path = "crates/bevy_mod_stylebuilder", version = "0.1.3" }
 bevy_mod_picking = { version = "0.20.1", default-features = false }
 bevy_quill_core = { path = "crates/bevy_quill_core", version = "0.1.3" }
@@ -25,11 +26,6 @@ bevy_quill_obsidian = { path = "crates/bevy_quill_obsidian", version = "0.1.3" }
 bevy_quill_obsidian_inspect = { path = "crates/bevy_quill_obsidian_inspect", version = "0.1.2" }
 bevy_quill_obsidian_graph = { path = "crates/bevy_quill_obsidian_graph", version = "0.1.2" }
 bevy_quill_overlays = { path = "crates/bevy_quill_overlays", version = "0.1.2" }
-
-[workspace.dependencies.bevy]
-version = "0.14"
-default-features = false
-features = ["bevy_ui"]
 
 [dependencies]
 bevy = { workspace = true }
@@ -39,7 +35,6 @@ impl-trait-for-tuples = "0.2.2"
 smallvec = "1.13.2"
 
 [dev-dependencies]
-bevy = { workspace = true, features = ["bevy_state", "multi_threaded"] }
 bevy_quill_obsidian = { path = "crates/bevy_quill_obsidian" }
 bevy_mod_picking = { workspace = true, features = [
   "debug",

--- a/crates/bevy_quill_overlays/Cargo.toml
+++ b/crates/bevy_quill_overlays/Cargo.toml
@@ -13,6 +13,6 @@ bevy_mod_picking = { workspace = true, features = [
   "backend_raycast",
   "backend_bevy_ui",
 ] }
-bevy = { workspace = true, features = ["bevy_pbr"] }
+bevy = { workspace = true }
 # bevy_mod_stylebuilder = { workspace = true }
 bevy_quill_core = { workspace = true }

--- a/crates/bevy_vortex/Cargo.toml
+++ b/crates/bevy_vortex/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/viridia/quill"
 keywords = ["bevy", "ui", "reactive"]
 
 [dependencies]
-bevy = { workspace = true, features = ["bevy_state"] }
+bevy = { workspace = true }
 bevy_mod_picking = { workspace = true, features = ["debug", "backend_bevy_ui"] }
 bevy_mod_stylebuilder = { workspace = true }
 bevy_quill = { path = "../.." }


### PR DESCRIPTION
Reverts viridia/quill#16

This actually broke a number of things. `cargo build` works, but `cargo build -p vortex` doesn't, and even when I fixed those issues, the asset system broke. So I'm going to revert this for now.